### PR TITLE
Split tweet to sentences before parsing

### DIFF
--- a/src/baseline_automatic_pipeline_system/okr_for_mds.py
+++ b/src/baseline_automatic_pipeline_system/okr_for_mds.py
@@ -193,7 +193,7 @@ if __name__ == "__main__":
     tweets_strings = {tweet_id : tweet["string"] for tweet_id, tweet in tweets.iteritems() }
     # retrieve okr info - explicitly call all pipeline stages, for debugging
     import parse_okr_info as prs
-    parsed_sentences = prs.parse_single_sentences(tweets_strings)
+    parsed_sentences = prs.parse_tweets(tweets_strings)
     all_entity_mentions, all_proposition_mentions = prs.get_mention_lists(parsed_sentences)
     entities = prs.cluster_entities(all_entity_mentions)
     propositions = prs.cluster_propositions(all_proposition_mentions, all_entity_mentions, entities)

--- a/src/baseline_automatic_pipeline_system/parse_okr_info.py
+++ b/src/baseline_automatic_pipeline_system/parse_okr_info.py
@@ -61,12 +61,10 @@ def parse_tweets(raw_sentences):
     # parse each tweet and store entity and proposition extractions
     parsed_sentences = {}
     for sent_id, sent in normed_sentences.iteritems():
-        # try:
-        #     parsed_sentences[sent_id] = parse_tweet(sent)
-        # except Exception as e:
-        #     logging.error("failed to parse sentence: " + sent +" | Error: " + str(e))
-        parsed_sentences[sent_id] = parse_tweet(sent)
-
+        try:
+            parsed_sentences[sent_id] = parse_tweet(sent)
+	except Exception as e:
+            logging.error("failed to parse sentence: " + sent +" | Error: " + str(e))
     return parsed_sentences
 
 def parse_tweet(tweet_text):
@@ -78,8 +76,6 @@ def parse_tweet(tweet_text):
     def props_parse(sent):
         props_wrapper.parse(sent)
         return props_wrapper.get_okr()
-
-    #return props_parse(tweet_text)
 
     # use Spacy to segment tweet to sentences
     doc = spacy_pipe(unicode(tweet_text))

--- a/src/baseline_automatic_pipeline_system/parse_okr_info.py
+++ b/src/baseline_automatic_pipeline_system/parse_okr_info.py
@@ -63,7 +63,7 @@ def parse_tweets(raw_sentences):
     for sent_id, sent in normed_sentences.iteritems():
         try:
             parsed_sentences[sent_id] = parse_tweet(sent)
-	except Exception as e:
+        except Exception as e:
             logging.error("failed to parse sentence: " + sent +" | Error: " + str(e))
     return parsed_sentences
 
@@ -81,7 +81,10 @@ def parse_tweet(tweet_text):
     doc = spacy_pipe(unicode(tweet_text))
     # parse each sentence separately using props
     props_parses = [props_parse(s.text) for s in doc.sents]
-    # return a merge of the parses
+    # if single sentence, return props parse
+    if len(props_parses)==1:
+        return props_parses[0]
+    # if multiple sentences in tweet, return a merge of the parses
     return combine_parses(doc, props_parses)
 
 def combine_parses(spacy_doc, props_parses):

--- a/src/baseline_system/parsers/props_wrapper.py
+++ b/src/baseline_system/parsers/props_wrapper.py
@@ -193,7 +193,7 @@ class PropSWrapper:
                     "Lemma": PropSWrapper.IMPLICIT_SYMBOL[0],
                     "POS": PropSWrapper.IMPLICIT_SYMBOL[0]
                 },
-                "Arguments": arg_symbols
+                "Arguments": list(arg_symbols)
             }
 
     # retrieve spacy's named entities, only those with relevant label


### PR DESCRIPTION
before passing the tweet text to props_wrapper, we first segment it to sentences using Spacy.
Then, we merge the props_wrapper outputs to a single parse, by:
1. modifying indices to match the full tweet text
2. modifying the symbols (entity-id and predicate-id) to a unified list, sorted by the (first) word index. 